### PR TITLE
Add Render deployment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-This repository is production-ready pending environment configuration in Vercel.
+This repository is production-ready pending environment configuration in Render or Vercel.
 
 ---
 
@@ -22,7 +22,41 @@ Run `npm install` and `npm run dev`.
 
 ---
 
-## Production Deploy Checklist
+## Render Deploy Checklist
+
+This repository includes a root `render.yaml` blueprint for deploying the app as a Render Node web service.
+
+Before deploying to Render, complete the following:
+
+1. **Create or connect a PostgreSQL database**
+   - Set `DATABASE_URL` in Render environment variables.
+   - Use a valid PostgreSQL connection string.
+
+2. **Set `NEXT_PUBLIC_APP_URL`**
+   - Example: `https://shuffle-the-deck.onrender.com`
+
+3. **Set `ADMIN_PASSPHRASE`**
+   - Do not commit this value.
+
+4. **Ensure `ENABLE_STRIPE_MOCK_WEBHOOK` is `false`**
+   - The Render blueprint sets this to `false`.
+
+5. **Build and start commands**
+   - Build: `npm run render:build`
+   - Start: `npm run render:start`
+
+6. **Apply Prisma schema when needed**
+   - First deployment or schema changes may require:
+
+```bash
+npm run prisma:push
+```
+
+See `docs/render.md` for the full Render setup notes.
+
+---
+
+## Vercel Production Deploy Checklist
 
 Before deploying to Vercel Production, complete the following:
 
@@ -46,13 +80,14 @@ vercel --prod
 > **Note:** `prisma generate` runs automatically during `npm run build` via the build script.
 > You only need to run `prisma db push` manually the first time or after schema changes.
 
-### Required Vercel Environment Variables
+### Required Production Environment Variables
 
 - DATABASE_URL (PostgreSQL)
 - NEXT_PUBLIC_APP_URL
-- OPENAI_API_KEY
 - ADMIN_PASSPHRASE
 - ENABLE_STRIPE_MOCK_WEBHOOK=false
+
+If runtime AI provider features are enabled in the future, add provider keys as deployment-platform secrets. Do not commit them to the repository.
 
 ---
 
@@ -61,3 +96,4 @@ vercel --prod
 - Stripe mock routes are disabled in production via environment flags.
 - All analysis routes are server-validated via Zod schemas.
 - No client-side mutation of canonical state is trusted.
+- Deployment changes should preserve the SHUFFLE product constraints: card-model-first surfaces, canonical objects as source of truth, deterministic runtime behavior where required, and grounded non-mystical product language.

--- a/docs/render.md
+++ b/docs/render.md
@@ -1,0 +1,56 @@
+# Render deployment
+
+This repository can be deployed to Render as a Node web service using the root `render.yaml` blueprint.
+
+## Blueprint
+
+`render.yaml` defines one web service:
+
+- Runtime: Node
+- Build command: `npm install && npm run render:build`
+- Start command: `npm run render:start`
+- Health check path: `/`
+
+The Render-specific npm scripts are defined in `package.json`:
+
+```bash
+npm run render:build
+npm run render:start
+```
+
+## Required Render environment variables
+
+Set these in the Render dashboard. Do not commit real values.
+
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `DATABASE_URL` | Yes | PostgreSQL connection string used by Prisma. |
+| `NEXT_PUBLIC_APP_URL` | Yes | Public Render URL, for example `https://shuffle-the-deck.onrender.com`. |
+| `ADMIN_PASSPHRASE` | Yes | Admin access passphrase. |
+| `ENABLE_STRIPE_MOCK_WEBHOOK` | Yes | Keep set to `false` in production. |
+| `NODE_VERSION` | Yes | Set by the blueprint to `20`. |
+
+If future runtime AI features need provider credentials, add those secrets in Render's dashboard rather than committing them.
+
+## Database setup
+
+`npm run render:build` runs `prisma generate` before `next build`.
+
+For the first deploy, or after Prisma schema changes, apply the schema to the Render database from a controlled shell or Render one-off job:
+
+```bash
+npm run prisma:push
+```
+
+Use destructive flags only when you intentionally accept data loss.
+
+## Product constraints
+
+Render deployment must preserve the SHUFFLE operating constraints:
+
+- Keep the app card-model-first.
+- Treat canonical server data as the source of truth.
+- Keep deterministic runtime behavior where product meaning depends on canonical objects.
+- Do not add runtime bespoke image generation to the critical loop.
+- Keep public product copy grounded and non-mystical.
+- Do not commit secrets, generated environment files, or provider keys.

--- a/package.json
+++ b/package.json
@@ -2,12 +2,19 @@
   "name": "defrag",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=20 <21"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest"
+    "test": "vitest",
+    "prisma:generate": "prisma generate",
+    "prisma:push": "prisma db push",
+    "render:build": "prisma generate && next build",
+    "render:start": "next start -p ${PORT:-3000}"
   },
   "dependencies": {
     "next": "latest",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,22 @@
+services:
+  - type: web
+    name: shuffle-the-deck
+    runtime: node
+    plan: starter
+    region: oregon
+    branch: main
+    buildCommand: npm install && npm run render:build
+    startCommand: npm run render:start
+    healthCheckPath: /
+    autoDeploy: true
+    envVars:
+      - key: NODE_VERSION
+        value: "20"
+      - key: NEXT_PUBLIC_APP_URL
+        sync: false
+      - key: DATABASE_URL
+        sync: false
+      - key: ADMIN_PASSPHRASE
+        sync: false
+      - key: ENABLE_STRIPE_MOCK_WEBHOOK
+        value: "false"


### PR DESCRIPTION
## Summary

- Add Render-specific npm scripts and Node engine metadata.
- Add a root `render.yaml` blueprint for a Render Node web service.
- Add `docs/render.md` with Render setup, environment variables, database setup, and SHUFFLE product constraints.
- Update `README.md` with a Render deploy checklist while preserving the existing Vercel notes.

## Notes

- No secrets or API keys are committed.
- `OPENAI_API_KEY` was intentionally not added to `render.yaml`; add future provider keys in the Render dashboard only if runtime AI features require them.
- Prisma generation runs during Render build via `npm run render:build`.

## Validation

Not run locally from this chat environment. Please run in CI or locally:

```bash
npm install
npm run lint
npm test
npm run render:build
```

Closes #2